### PR TITLE
Add missing use statements in test file

### DIFF
--- a/t/03-optionset.t
+++ b/t/03-optionset.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use Getopt::Kinoko;
+use Getopt::Kinoko::Option;
 use Getopt::Kinoko::OptionSet;
 
 plan 24;

--- a/t/04-deepclone.t
+++ b/t/04-deepclone.t
@@ -2,6 +2,7 @@
 use v6;
 use Test;
 use Getopt::Kinoko;
+use Getopt::Kinoko::Group;
 use Getopt::Kinoko::Option;
 use Getopt::Kinoko::OptionSet;
 use Getopt::Kinoko::NonOption;


### PR DESCRIPTION
The design of Perl 6 requires that use statements only have effect in a
lexical scope. Otherwise it's impossible to use different (versions of)
modules sharing a name in different parts of a program.

This means essentially that we need to explicitly use all modules we need
in a scope.

See https://gist.github.com/niner/70f7b46eefb7e22af78d896bea11efeb for
further information.