### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"        : "6.c",
     "name"        : "Getopt::Kinoko",
+    "license"     : "MIT",
     "version"     : "0.2.9",
     "description" : "A command line parsing tool which written in Perl6",
     "depends"     : ["Terminal::WCWidth"],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license